### PR TITLE
Use ROOT::Fit::Fitter to fit Cartesian+Z

### DIFF
--- a/src/modules/lrf_v3/corelrfstypes.h
+++ b/src/modules/lrf_v3/corelrfstypes.h
@@ -112,6 +112,8 @@ protected:
   bool loadScriptVarFromJson(const QJsonObject &json, QScriptValue &var, QScriptValue &var_sigma) const;
   bool rootFitToScriptVar(const std::vector<AScriptParamInfo> &param_info,
                           const TFitResultPtr &fit, QScriptValue &script_var) const;
+  bool rootFitToScriptVar(const std::vector<AScriptParamInfo> &param_info,
+                          const std::vector<double> &fitted_params, QScriptValue &script_var) const;
 
 public:
   QJsonObject lrfToJson(const ALrf *lrf) const override;


### PR DESCRIPTION
The new attempt to make Cartesian+Z work on windows. Still doesn't work, because fit.Result() is badly formed.